### PR TITLE
Fix phash comparison in dedup script

### DIFF
--- a/dedup_deep.py
+++ b/dedup_deep.py
@@ -253,9 +253,12 @@ def assign_groups(groups):
                                 })
                         else:
                                 # If the perceptual hashes are identical, skip computing pixel differences.
-                                diff = (pixel_diff(bp, mp)
-                                                if int(best.get(PHASH_COL or "0"), 16) != int(r.get(PHASH_COL or "0"), 16)
-                                                else 0.0)
+                                diff = (
+                                        pixel_diff(bp, mp)
+                                        if int(best.get(PHASH_COL) or "0", 16)
+                                        != int(r.get(PHASH_COL) or "0", 16)
+                                        else 0.0
+                                )
                                 is_dup = diff <= PIXEL_DIFF_THRESHOLD
                                 if is_dup:
                                         r.update({


### PR DESCRIPTION
## Summary
- fix phash comparison logic in `dedup_deep.py`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb36f5ad88333baef14b8326fe2cb