### PR TITLE
Avoid duplicate failed move for timestamp errors

### DIFF
--- a/metadata.py
+++ b/metadata.py
@@ -299,9 +299,9 @@ def main():
         if success:
             row['action_taken'] += f"; {msg}" if row['action_taken'] else msg
         else:
-            moved, reason = move_to_failed(str(media_path), msg)
-            row['action_taken'] = f"Moved to failed: {moved}" if moved else ''
-            row['notes'] = reason
+            log(f"File already moved to failed during timestamp update: {media_path}")
+            row['action_taken'] += "; Already moved to failed" if row['action_taken'] else "Already moved to failed"
+            row['notes'] = msg
 
     # Write the updated data back to the manifest CSV file
     fieldnames = [


### PR DESCRIPTION
## Summary
- avoid moving a file twice when `update_timestamp` already failed
- preserve previous actions and add note the file was already moved

## Testing
- `python3 test.py` *(fails: ModuleNotFoundError: No module named 'cupy')*

------
https://chatgpt.com/codex/tasks/task_e_683fb4a9f8c88333b3f6c349dd0bdb77